### PR TITLE
windows fixes

### DIFF
--- a/src/cache_directory.rs
+++ b/src/cache_directory.rs
@@ -41,7 +41,7 @@ impl Cache {
         }
     }
 
-    fn get_extracted_dir_tar(&self, file_name: &str) -> Result<String> {
+    fn get_extracted_dir_tar(&self, file_name: &str) -> Result<String> { 
         let tarball = fs::File::open(format!("{}/bin/{file_name}", self.location))?;
         let tar = GzDecoder::new(tarball);
         let mut archive = Archive::new(tar);
@@ -65,16 +65,24 @@ impl Cache {
     }
 
     pub fn get_extracted_dir_zip(&self, file_name: &str) -> Result<String> {
-        let tarball = fs::File::open(format!("{}/bin/{file_name}", self.location))?;
+        // When unzipped, it doesn't need extra processing to get directory (like tar->gz does)
+        println!("{}/bin/", self.location);
+        let extracted_dir_path = format!("{}\\bin\\", self.location);
+        let mut extracted_dir = fs::read_dir(extracted_dir_path)?;
 
         let mut name = String::new();
 
-        let reader = std::io::BufReader::new(tarball);
-        let mut archive = ZipArchive::new(reader).unwrap();
-        let file = archive.by_index(0).unwrap();
-
-        name.push_str(file.name());
-        name.truncate(name.len() - 1);
+        // Get the name of the already extracted directory
+        if let Some(dir) = extracted_dir.next() {
+            let dir = dir.unwrap();
+            name.push_str(
+                dir.path()
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .expect("Unable to get extracted directory name"),
+            );
+        };
 
         Ok(name)
     }

--- a/src/packages/common.rs
+++ b/src/packages/common.rs
@@ -103,13 +103,13 @@ pub fn link(cache: &Cache, version: &str, from: &str, to: &str) -> Result<()> {
 
     // windows
     #[cfg(any(windows, doc))]
-    if name == "std" {
+    if from == "std" {
         std::os::windows::fs::symlink_dir(
             format!("{}\\bin\\{version}\\{from}", cache.location),
             format!("{}\\{to}", cache.location),
         )
         .wrap_err(format!(
-            "I was unable to create a symlink from {0}\\bin\\{version} to {0}\\{name}",
+            "I was unable to create a symlink from {0}\\bin\\{version} to {0}\\{from}",
             cache.current_version()
         ))?;
     } else {
@@ -118,7 +118,7 @@ pub fn link(cache: &Cache, version: &str, from: &str, to: &str) -> Result<()> {
             format!("{}\\{to}", cache.location),
         )
         .wrap_err(format!(
-            "I was unable to create a symlink from {0}\\bin\\{version} to {0}\\{name}",
+            "I was unable to create a symlink from {0}\\bin\\{version} to {0}\\{from}",
             cache.current_version()
         ))?;
     }
@@ -140,8 +140,21 @@ pub fn link_haxe(cache: &Cache, version: String) -> Result<()> {
 
     println!("🎉 You are now on Haxe {}", style(&version).yellow());
     if cfg!(target_os = "windows") {
+        // Check if HAXEPATH is set
+        if std::env::var("HAXEPATH").is_err() {
         println!("Note: You will need to run `setx /M HAXEPATH {}` and add `%HAXEPATH%` to your PATH vars to use this version of Haxe!", Cache::get_path().unwrap() + "\\haxe");
+        }
+
+        // Check if HAXEPATH is in PATH
+        let path = std::env::var("PATH").unwrap_or_default();
+        let haxepath = format!("{}\\haxe", Cache::get_path().unwrap());
+
+        
+        if !path.contains(&haxepath) {
+            println!("Warning: HAXEPATH is not in your PATH. Add `%HAXEPATH%` to your PATH vars to use this version of Haxe!");
+        }
     } else if std::env::var("HAXE_STD_PATH").is_err() {
+        // Handle the case for non-windows OS here
         println!("Note: You will need to add `export HAXE_STD_PATH={}/std/` to your shell config (i.e ~/.bashrc or ~/.zshrc)", Cache::get_path().unwrap());
     }
 


### PR DESCRIPTION
- When downloading the .zip, it doesn't need any extra processing steps that tar->gz does, so it gets the outputted directory
- Some extra detail if HAXEPATH exists, and if HAXEPATH is in PATH

in `cache_directory.get_extracted_dir_zip()` it doesn't need the `file_name` arg, however I left it be for now. 