### PR TITLE
Cheesy Fix for Neko

### DIFF
--- a/src/packages/neko.rs
+++ b/src/packages/neko.rs
@@ -62,7 +62,7 @@ fn get_tarball(cache: &Cache, file_name: &str) -> Result<fs::File, Error> {
         Ok(file) => Ok(file),
         Err(e) => match e.kind() {
             ErrorKind::NotFound => {
-                let alt_path = format!("{}/bin/{file_name}", cache.location, file_name);
+                let alt_path = format!("{}/bin/{file_name}", cache.location);
                 return fs::File::open(alt_path);
             },
             _ => return Err(e)


### PR DESCRIPTION
For some reason, the `.tar.gz` file is moved to the `bin/` directory instead of the `bin/neko/`, so I made it so that it checks to see if the file is located in either directory.

Now Neko works on Mac when installing.